### PR TITLE
Delete email

### DIFF
--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -4,7 +4,7 @@ class UserSessionsController < ApplicationController
     def new ;end
 
     def create
-      @user = login(params[:email], params[:password])
+      @user = login(params[:username], params[:password])
       if @user
         redirect_back_or_to myscore_url, success: t('defaults.message.login')
       else
@@ -21,6 +21,6 @@ class UserSessionsController < ApplicationController
     private
 
     def user_params
-      params.require(:user).permit(:email, :password)
+      params.require(:user).permit(:username, :password)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -18,6 +18,6 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:email, :username, :password, :password_confirmation)
+    params.require(:user).permit(:username, :password, :password_confirmation)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,8 +6,8 @@ class User < ApplicationRecord
   has_many :flowers, dependent: :destroy
   has_many :flowered_kusocodes, through: :flowers, source: :kusocode
 
-  validates :username, presence: true, length: { maximum: 20 }
-  validates :email, presence: true, uniqueness: true
+  validates :username, presence: true, length: { maximum: 20 }, uniqueness: true
+  # validates :email, presence: true, uniqueness: true
 
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/scores/index.html.erb
+++ b/app/views/scores/index.html.erb
@@ -14,12 +14,6 @@
           <%= render 'ranking', records: @lv1_records %>
         </div>
         <!-- /ranking-container -->
-        <!-- ranking-container -->
-        <div class='ranking-container mt-5'>
-          <h5><%= Record.human_attribute_name(:level) %>: <%= t('.level2') %></h5>
-          <%= render 'ranking', records: @lv2_records %>
-        </div>
-        <!-- /ranking-container -->
       </div>
     </div>
   </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -34,7 +34,7 @@
           <span class="border-start border-white mx-2"></span>
           <% if logged_in? %>
             <div class='dropstart text-center'>
-              <button type='button' class='btn dropdown-toggle' data-bs-toggle='dropdown' aria-expanded='false'>
+              <button type='button' class='btn dropdown-toggle' data-bs-toggle='dropdown' aria-expanded='false' id='mypage-icon'>
                 <%= image_tag 'icon_user.png', size: '30x30', class: 'p-0 m-auto' %>
               </button>
               <ul class='dropdown-menu'>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -16,8 +16,8 @@
       <% end %>
       <div class='text-center mt-3'>
         <%= link_to t('users.new.title'), new_user_path %>
-        /
-        <%= link_to t('defaults.message.forget_password'), '#' %>
+        <!-- / -->
+        <!-- ※後日実装予定 %= link_to t('defaults.message.forget_password'), '#' % -->
       </div>
     </div>
   </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -5,8 +5,8 @@
       <h1><%= t('.title') %></h1>
       <%= form_with url: login_path, local: true do |f| %>
         <div class='form-group'>
-          <%= f.label :email, User.human_attribute_name(:email) %>
-          <%= f.email_field :email, class: 'form-control mb-3' %>
+          <%= f.label :username, User.human_attribute_name(:username) %>
+          <%= f.text_field :username, class: 'form-control mb-3' %>
         </div>
         <div class='form-group'>
           <%= f.label :password, User.human_attribute_name(:password) %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -10,10 +10,6 @@
           <%= f.text_field :username, class: 'form-control mb-3' %>
         </div>
         <div class='form-group'>
-          <%= f.label :email %>
-          <%= f.email_field :email, class: 'form-control mb-3' %>
-        </div>
-        <div class='form-group'>
           <%= f.label :password %>
           <%= f.password_field :password, class: 'form-control mb-3' %>
         </div>

--- a/config/initializers/sorcery.rb
+++ b/config/initializers/sorcery.rb
@@ -221,7 +221,7 @@ Rails.application.config.sorcery.configure do |config|
     # Specify username attributes, for example: [:username, :email].
     # Default: `[:email]`
     #
-    # user.username_attribute_names =
+    user.username_attribute_names = [:username]
 
     # Change *virtual* password attribute, the one which is used until an encrypted one is generated.
     # Default: `:password`

--- a/db/migrate/20221229014219_remove_email_from_users.rb
+++ b/db/migrate/20221229014219_remove_email_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveEmailFromUsers < ActiveRecord::Migration[5.2]
+  def change
+    remove_column :users, :email, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_22_152220) do
+ActiveRecord::Schema.define(version: 2022_12_29_014219) do
 
   create_table "flowers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.bigint "user_id"
@@ -51,12 +51,10 @@ ActiveRecord::Schema.define(version: 2022_12_22_152220) do
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "username", null: false
-    t.string "email", null: false
     t.string "crypted_password"
     t.string "salt"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
   end
 
   add_foreign_key "flowers", "kusocodes"

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :user do
     username { 'テストユーザー' }
-    email { 'test@example.com' }
     password { 'password' }
     password_confirmation { 'password' }
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   describe 'バリデーションテスト' do
     let(:user) { FactoryBot.create(:user) }
+    let(:user_b){ FactoryBot.create(:user, username: 'user_b') }
     subject { user.valid? }
     context 'usernameカラムにおいて' do
       it 'usernameは必ず存在すること' do
@@ -17,15 +18,10 @@ RSpec.describe User, type: :model do
         user.username = '0' * 21
         is_expected.to eq false;
       end
-    end
-    context 'emailカラムにおいて' do
-      it 'emailは必ず存在すること' do
-        user.email = ''
-        is_expected.to eq false;
-      end
-      it 'emailは一意であること(同じemailは許容しない)' do
-        another_user = FactoryBot.build(:user, email: user.email)
-        expect(another_user.valid?).to eq false;
+      it '重複するusernameは登録できないこと' do
+        user_b
+        user.username = user_b.username
+        is_expected.to eq false
       end
     end
     context 'passwordにおいて' do

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+describe 'ユーザー管理機能' do
+  describe 'ユーザー新規作成機能' do
+    let(:user_a){ FactoryBot.create(:user, username: 'user_a') }
+    context '全ての項目に入力したら' do
+      before do
+        visit new_user_path
+        fill_in 'ユーザー名', with: 'user'
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード確認', with: 'password'
+        click_button '登録する'
+      end
+      it 'ユーザー新規作成できるか' do
+        expect(page).to have_content 'ユーザーを作成しました'
+      end
+    end
+    context 'ユーザー名を空欄にすると' do
+      before do
+        visit new_user_path
+        fill_in 'ユーザー名', with: ''
+        fill_in 'パスワード', with: 'password'
+        fill_in 'パスワード確認', with: 'password'
+        click_button '登録する'
+      end
+      it 'ユーザー作成に失敗するか' do
+        expect(page).to have_content 'ユーザーを作成できませんでした'
+      end
+    end
+    context 'パスワードを空欄にすると' do
+      before do
+        visit new_user_path
+        fill_in 'ユーザー名', with: 'user'
+        fill_in 'パスワード', with: ''
+        fill_in 'パスワード確認', with: 'password'
+        click_button '登録する'
+      end
+      it 'ユーザー作成に失敗するか' do
+        expect(page).to have_content 'ユーザーを作成できませんでした'
+      end
+    end
+  end
+  describe 'ログイン機能' do
+    let!(:user_a){ FactoryBot.create(:user, username: 'user_a') }
+    context '登録済のユーザーがログインを試みると' do
+      before do
+        visit login_path
+        fill_in 'ユーザー名', with: user_a.username
+        fill_in 'パスワード', with: 'password'
+        click_button 'ログイン'
+      end
+      it 'ログインできるか' do
+        expect(page).to have_content "#{user_a.username}の成績"
+      end
+    end
+    context 'ユーザー名に空欄があると' do
+      before do
+        visit login_path
+        fill_in 'ユーザー名', with: ''
+        fill_in 'パスワード', with: 'password'
+        click_button 'ログイン'
+      end
+      it 'ログイン失敗するか' do
+        expect(page).to have_content 'ログインできませんでした'
+      end
+    end
+    context 'パスワードに空欄があると' do
+      before do
+        visit login_path
+        fill_in 'ユーザー名', with: user_a.username
+        fill_in 'パスワード', with: ''
+        click_button 'ログイン'
+      end
+      it 'ログイン失敗するか' do
+        expect(page).to have_content 'ログインできませんでした'
+      end
+    end
+  end
+  describe 'ログアウト機能' do
+    let!(:user_a){ FactoryBot.create(:user, username: 'user_a') }
+    context 'user_aでログインしている時' do
+      before do
+        visit login_path
+        fill_in 'ユーザー名', with: user_a.username
+        fill_in 'パスワード', with: 'password'
+        click_button 'ログイン'
+        find_by_id('mypage-icon').click
+        click_on 'ログアウト'
+      end
+      it 'ログアウトできること' do
+        expect(page).to have_content 'ログアウトしました'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Userモデルからemailカラムを消し、emailでユーザー識別していたものをusernameで識別するように設定を変更しました。

なぜ変えたのか？
・emailでの識別だとユーザーがemailを容易には預けてくれず、顧客獲得に支障が出ると思われたから。
・emailを登録したとして、使用機会がpasswordを忘れた時ぐらいしかないから。
・passwordを忘れた時は質問と適切な回答をユーザー登録時に一緒に記録してもらい、そこからユーザー識別を行うことにする。（後日実装予定）